### PR TITLE
docs: Add SECURITY.md with instructions on reporting vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ The following projects and versions are currently supported with security update
 ## Reporting a Vulnerability
 
 If you find a security vulenerability in one of our projects, email us
-at [support@unstructured.io](mailto?support@unstructured.io?subject=Security%20Vulnerability%20Report)
+at [support@unstructured.io](mailto:support@unstructured.io?subject=Security%20Vulnerability%20Report)
 with the subject line "Security Vulnerability Report". We will respond within 72 hours with a
 decision on whether your security report is accepted or declined. We will update you when
 the reported vulnerability is fixed or mitigated.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+The following projects and versions are currently supported with security updates.
+
+| Package | Version | Supported          |
+| ------- | ------- | ------------------ |
+| `unstructured` | All versions   | :white_check_mark: |
+| `unstructured-api-tools` | All versions   | :white_check_mark: |
+| `pipeline-sec-filings` | All versions   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you find a security vulenerability in one of our projects, email us
+at [support@unstructured.io](mailto?support@unstructured.io?subject=Security Vulnerability Report)
+with the subject line "Security Vulnerability Report". We will respond within 72 hours with a
+decision on whether your security report is accepted or declined. We will update you when
+the reported vulnerability is fixed or mitigated.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ The following projects and versions are currently supported with security update
 ## Reporting a Vulnerability
 
 If you find a security vulenerability in one of our projects, email us
-at [support@unstructured.io](mailto?support@unstructured.io?subject=Security Vulnerability Report)
+at [support@unstructured.io](mailto?support@unstructured.io?subject=Security%20Vulnerability%20Report)
 with the subject line "Security Vulnerability Report". We will respond within 72 hours with a
 decision on whether your security report is accepted or declined. We will update you when
 the reported vulnerability is fixed or mitigated.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,5 +15,6 @@ The following projects and versions are currently supported with security update
 If you find a security vulenerability in one of our projects, email us
 at [support@unstructured.io](mailto:support@unstructured.io?subject=Security%20Vulnerability%20Report)
 with the subject line "Security Vulnerability Report". We will respond within 72 hours with a
-decision on whether your security report is accepted or declined. We will update you when
-the reported vulnerability is fixed or mitigated.
+decision on whether your security report is accepted or declined. Do not open an issue yourself,
+we will open an issue if your vulnerability is accepted. The issue will be not be public to avoid
+publicizing the vulnerability. We will update you when the reported vulnerability is fixed or mitigated.


### PR DESCRIPTION
### Summary

Addresses [CORE-149](https://unstructured-ai.atlassian.net/browse/CORE-149). Adds a `SECURITY.md` file with instructions on how to report security vulnerabilities. Since this is in the `.github` repo, this will be applied as the default security policy for all repos in the organization. The format is based on the GitHub's suggested format.