### PR TITLE
docs: Add a link to the OER pipeline

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -18,6 +18,8 @@ for downstream data science tasks. Check out our core repos:
   machine learning workflows.
 - [`pipeline-sec-filings`](https://github.com/Unstructured-IO/pipeline-sec-filings) - A document
   pre-processing pipeline for SEC filings focused on 10-Ks, 10-Qs, and S-1s.
+- [`pipeline-oer`](https://github.com/Unstructured-IO/pipeline-oer) - A document
+  pre-processing pipeline for US Army Officer Evaluation Reports (OERs).
 - [`community`](https://github.com/Unstructured-IO/community) - Repo with issues for community
   contributors and guidelines on how to contribute.
 


### PR DESCRIPTION
### Summary

Links to the `pipeline-oer` repo.

### Testing

Test that the link works in the `README` file [here](https://github.com/Unstructured-IO/.github/tree/robinson/add-oer-link/profile).