### PR TITLE
docs: add links to linkedin and slack 

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,6 +2,17 @@
   <img src="img/unstructured_logo.png" height="200">
 </h3>
 
+<div>
+  <p align="center">
+  <a
+  href="https://join.slack.com/t/unstructuredw-kbe4326/shared_invite/zt-1nlh1ot5d-dfY7zCRlhFboZrIWLA4Qgw">
+    <img src="https://img.shields.io/badge/JOIN US ON SLACK-4A154B?style=for-the-badge&logo=slack&logoColor=white" />
+  </a>
+  <a href="https://www.linkedin.com/company/unstructuredio/">
+    <img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" />
+  </a>
+</div>
+
 <h3 align="center">
   <p>Open-Source Pre-Processing Tools for Unstructured Data</p>
 </h3>


### PR DESCRIPTION
### Summary

Adds links to the community Slack and our LinkedIn page to the README.

### Testing

Click the links to make sure they work.