### PR TITLE
Fixed link to new logo on README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,8 @@
 <h3 align="center">
-  <img src="img/unstructured_logo.png" height="200">
+  <img
+    src="https://raw.githubusercontent.com/Unstructured-IO/unstructured/main/img/unstructured_logo.png"
+    height="200"
+  >
 </h3>
 
 <div>


### PR DESCRIPTION
Issue: the Unstructured's new logo is not showing on the README.md