### PR TITLE
Update README.md to point to new documentation site

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -45,4 +45,4 @@ Platform, and ETL tool built around our core file transformation capabilities.
 | Section | Description |
 |-|-|
 | [Company Website](https://unstructured.io) | Unstructured.io product and company info |
-| [Documentation](https://unstructured-io.github.io/unstructured) | Full `unstructured` documentation |
+| [Documentation]([https://unstructured-io.github.io/unstructured](https://docs.unstructured.io/) | Full `unstructured` documentation |

--- a/profile/README.md
+++ b/profile/README.md
@@ -45,4 +45,4 @@ Platform, and ETL tool built around our core file transformation capabilities.
 | Section | Description |
 |-|-|
 | [Company Website](https://unstructured.io) | Unstructured.io product and company info |
-| [Documentation]([https://unstructured-io.github.io/unstructured](https://docs.unstructured.io/) | Full `unstructured` documentation |
+| [Documentation](https://docs.unstructured.io/) | Full `unstructured` documentation |


### PR DESCRIPTION
https://unstructured-io.github.io/unstructured/ now says it has been superseded by https://docs.unstructured.io/